### PR TITLE
Fix action button behaviour.

### DIFF
--- a/android/src/main/java/com/fusionx/lightirc/ui/MainActivity.java
+++ b/android/src/main/java/com/fusionx/lightirc/ui/MainActivity.java
@@ -420,9 +420,9 @@ public class MainActivity extends ActionBarActivity implements ServerListFragmen
                 UIUtils.toggleSlidingPane(mSlidingPane);
                 return true;
             case R.id.activity_main_ab_actions:
-                UIUtils.toggleDrawerLayout(mDrawerLayout, mNavigationDrawerView);
+                boolean nowOpen = UIUtils.toggleDrawerLayout(mDrawerLayout, mNavigationDrawerView);
                 // If the drawer is now closed then we don't need to pass on the event
-                return !mDrawerLayout.isDrawerOpen(mNavigationDrawerView);
+                return !nowOpen;
             case R.id.activity_main_ab_users:
                 if (!mDrawerLayout.isDrawerOpen(mNavigationDrawerView)) {
                     mDrawerLayout.openDrawer(mNavigationDrawerView);

--- a/android/src/main/java/com/fusionx/lightirc/util/UIUtils.java
+++ b/android/src/main/java/com/fusionx/lightirc/util/UIUtils.java
@@ -54,12 +54,14 @@ public class UIUtils {
         }
     }
 
-    public static void toggleDrawerLayout(final DrawerLayout drawerLayout, final View drawer) {
-        if (drawerLayout.isDrawerOpen(drawer)) {
+    public static boolean toggleDrawerLayout(final DrawerLayout drawerLayout, final View drawer) {
+        boolean isOpen = drawerLayout.isDrawerOpen(drawer);
+        if (isOpen) {
             drawerLayout.closeDrawer(drawer);
         } else {
             drawerLayout.openDrawer(drawer);
         }
+        return !isOpen;
     }
 
     public static List<Integer> getCheckedPositions(final AbsListView listView) {


### PR DESCRIPTION
Make sure action panel is visible when pressing 'Actions'. Previously it
opened the 'Users' panel under those conditions:
- Press 'Users'
- Swipe out drawer
- Press 'Actions'

Root cause was that after openDrawer() isDrawerOpen() still returns
false, as it'll only return true after the animation finished.
