### PR TITLE
Reset notification state whenever the activity is entered.

### DIFF
--- a/android/src/main/java/com/fusionx/lightirc/util/NotificationUtils.java
+++ b/android/src/main/java/com/fusionx/lightirc/util/NotificationUtils.java
@@ -247,6 +247,7 @@ public class NotificationUtils {
                 (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
 
         notificationManager.cancel(NOTIFICATION_MENTION);
+        resetNotificationState();
     }
 
     private static CharSequence prependHighlightedText(Context context,


### PR DESCRIPTION
Otherwise new notifications will contain outdated information.