### PR TITLE
Fix an issue where message text occasionally becomes unselectable.

### DIFF
--- a/android/src/main/java/com/fusionx/lightirc/ui/IRCAdapter.java
+++ b/android/src/main/java/com/fusionx/lightirc/ui/IRCAdapter.java
@@ -70,6 +70,11 @@ public class IRCAdapter<T extends Event> extends RecyclerView.Adapter<IRCAdapter
     }
 
     @Override
+    public void onViewAttachedToWindow(IRCViewHolder holder) {
+        holder.message.setText(holder.message.getText());
+    }
+
+    @Override
     public int getItemCount() {
         synchronized (mLock) {
             return mObjects.size();


### PR DESCRIPTION
There's a full write-up in the commit message. This bug was a pain to track down.

(This is probably the only occasion when the excessive amount of logcat messages from the Android system libraries actually came in handy!)